### PR TITLE
ssh_key_adder.rb permissions

### DIFF
--- a/ssh_key_adder.rb
+++ b/ssh_key_adder.rb
@@ -3,8 +3,9 @@
 ENV_KEY = "AUTHORIZED_GH_USERS"
 
 begin
-  `mkdir /home/dev/.ssh`
+  `mkdir --mode=700 /home/dev/.ssh`
   `touch /home/dev/.ssh/authorized_keys`
+  `chmod 600 /home/dev/.ssh/authorized_keys`
   ENV[ENV_KEY].split(",").map(&:strip).each do |username|
     output = `gh-auth add --users=#{username}`
     if output.include?("Adding 0 key")


### PR DESCRIPTION
- Now creates .ssh as 700
- Now creates authorized_keys as 600
- See https://help.ubuntu.com/community/SSH/OpenSSH/Keys

(This will bite you if you update to Ubuntu 16.04)